### PR TITLE
Password remains the same if not edited while editing user

### DIFF
--- a/src/main/java/com/rpgrealm/rpgrealm/controllers/UsersController.java
+++ b/src/main/java/com/rpgrealm/rpgrealm/controllers/UsersController.java
@@ -62,8 +62,13 @@ public class UsersController {
 
   @PostMapping("/user-profile/edit/{id}")
   public String commitEditUser(@ModelAttribute User user){
-    String hash = passwordEncoder.encode(user.getPassword());
-    user.setPassword(hash);
+    User currentData=usrRep.findOne(user.getId());
+    if(!user.getPassword().equalsIgnoreCase("")){
+      String hash = passwordEncoder.encode(user.getPassword());
+      user.setPassword(hash);
+    }else{
+      user.setPassword(currentData.getPassword());
+    }
     usrRep.save(user);
     return "redirect:/user-profile";
   }


### PR DESCRIPTION
Issue: password would be set to an empty string if nothing was provided in the edit user profile page.

- [x] modify the controller to retrieve user password from the database if nothing is provided for the password field.